### PR TITLE
More absolute url fixes

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,19 +1,19 @@
 {% include header.html %}
 <div class="container">
 	<div class="profile">
-		<a href="//{{ site.url }}"><img src="{{site.author.picture}}" class="profile-image"></a>
+		<a href="//{{ site.url }}"><img src="//{{ site.url }}/{{site.author.picture}}" class="profile-image"></a>
 		<div class="profile-about">
 			<h2 style="margin-bottom: 0; font-weight: 700;">{{site.author.name}}</h2>
 			{% if site.author.github %}
-				<a href="https://github.com/{{site.author.github}}" target="_blank"><img src="assets/images/icon/github.svg" class="social-icon"></a>
+				<a href="https://github.com/{{site.author.github}}" target="_blank"><img src="//{{ site.url }}/assets/images/icon/github.svg" class="social-icon" alt="GitHub icon"></a>
 			{% endif %}
 			{% if site.author.linkedin %}
-				<a href="https://linkedin.com/in/{{site.author.linkedin}}" target="_blank"><img src="assets/images/icon/linkedin.svg" class="social-icon"></a>
+				<a href="https://linkedin.com/in/{{site.author.linkedin}}" target="_blank"><img src="//{{ site.url }}/assets/images/icon/linkedin.svg" class="social-icon" alt="LinkedIn icon"></a>
 			{% endif %}
 			{% if site.author.linkedin %}
-				<a href="https://androiddev.social/{{site.author.mastodon}}" target="_blank"><img src="assets/images/icon/mastodon.svg" class="social-icon"></a>
+				<a href="https://androiddev.social/{{site.author.mastodon}}" target="_blank"><img src="//{{ site.url }}/assets/images/icon/mastodon.svg" class="social-icon" alt="Mastodon icon"></a>
 			{% endif %}
-			<a href="about"><img src="assets/images/icon/me.svg" class="social-icon"></a>
+			<a href="about"><img src="//{{ site.url }}/assets/images/icon/me.svg" class="social-icon" alt="Person icon"></a>
 			<br>
 			{{ site.author.bio }}
 			<br>

--- a/_posts/2024-05-06-agp-tidbits-default-product-variant.md
+++ b/_posts/2024-05-06-agp-tidbits-default-product-variant.md
@@ -9,7 +9,7 @@ author: Antal Monori
 description: A quick guide on how to set a default Active Build Variant in Android Studio 
 ---
 
-![image](assets/posts/2024-05-06-agp-tidbits-default-product-variant/header.png)
+![image]({{ site.url }}/assets/posts/2024-05-06-agp-tidbits-default-product-variant/header.png)
 
 How often do you consider the experience of opening up your project in Android Studio for the first time? If you are in a small team, likely not too often. If you look after the developer experience of a large Android engineering team, you probably do!
 
@@ -19,7 +19,7 @@ Build variants can help you to define different versions of your app, like targe
 
 The above product flavor variations can create quite a long and complex list of Build Variants to choose from in Android Studio:
 
-![image](assets/posts/2024-05-06-agp-tidbits-default-product-variant/build-variants-before.png)
+![image]({{ site.url }}/assets/posts/2024-05-06-agp-tidbits-default-product-variant/build-variants-before.png)
 
 As you can notice, **this list is simply sorted in ascending alphabetical order** — and therefore the first one might not be the best configuration for someone just starting up with your project. If you want to encourage the use of `staging` over `production`, or `external` over `dev` by default, then please read on.
 
@@ -79,13 +79,13 @@ The above scenario will ensure that out of the api dimension staging will be pre
 
 Next time when an engineer clones your repository, or invalidates the module files for the application module, it would result in having devStagingDebug pre-selected to avoid any confusion.
 
-![image](assets/posts/2024-05-06-agp-tidbits-default-product-variant/build-variants-after.png)
+![image]({{ site.url }}/assets/posts/2024-05-06-agp-tidbits-default-product-variant/build-variants-after.png)
 
 ### How do I test this?
 
 If you inspect you application's generated module file (e.g. `.idea/modules/app/project-name.app.iml`), you'll find that this is where AGP injects the relevant information to tell Studio which one to prefer in the UI.
 
-![image](assets/posts/2024-05-06-agp-tidbits-default-product-variant/how-do-i-test.png)
+![image]({{ site.url }}/assets/posts/2024-05-06-agp-tidbits-default-product-variant/how-do-i-test.png)
 
 If you clear the right section, you should be ready to let Studio sync once again and you'll see the results.
 ----


### PR DESCRIPTION
## Context

Some content still doesn't load because of relative urls unable to properly load assets and link across pages

<img width="322" alt="image" src="https://github.com/user-attachments/assets/663b9317-fb5e-49ae-9124-3731afe07f53">


### Changes

Define more of the paths as absolute_urls