### PR TITLE
Update robots.txt to disallow AI crawlers but allow search engines

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,2 +1,39 @@
+# Allow all search engines
 User-agent: *
 Disallow:
+
+# Disallow known AI crawlers and searchbots
+User-agent: Google-Extended
+Disallow: /
+
+User-agent: GPTBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: ChatGPT-User
+Disallow: /
+
+User-agent: Slurp
+Disallow: /
+
+User-agent: YandexBot
+Disallow: /
+
+User-agent: Baiduspider
+Disallow: /
+
+User-agent: facebot
+Disallow: /
+
+User-agent: Sogou
+Disallow: /
+
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: SEMrushBot
+Disallow: /
+
+# You may add more AI crawler user-agents as they are identified


### PR DESCRIPTION
Asked chatgpt to generate one that includes all known AI crawlers as of today to disable them all while allowing the site to be crawled by genuine search engines. This should mainly target Google's Vertex AI crawler, ChatGPT and some other search engines like Yahoo, Baidu, Yandex, etc. This is to ensure we don't blow any unnecessary bandwith either.