### PR TITLE
Add mermaid diagram support

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ jobs:
         ruby-version: 3.2.3
     - uses: actions/setup-node@v4
       with:
-        node-version: '20'
+        node-version: '24'
     - name: Install mermaid-cli
       run: npm install -g @mermaid-js/mermaid-cli
     - name: Install Puppeteer dependencies

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.2.3
+        ruby-version: '3.4'
     - uses: actions/setup-node@v4
       with:
         node-version: '24'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,6 +10,18 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.2.3
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: Install mermaid-cli
+      run: npm install -g @mermaid-js/mermaid-cli
+    - name: Install Puppeteer dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libgbm1 libasound2 libatk1.0-0 \
+          libatk-bridge2.0-0 libcups2 libdrm2 libxcomposite1 \
+          libxdamage1 libxfixes3 libxrandr2 libxkbcommon0 \
+          libpango-1.0-0 libcairo2 libnss3 libnspr4
     - name: Install Jekyll and Bundler
       run: |
         gem install bundler

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Puppeteer dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgbm1 libasound2 libatk1.0-0 \
+        sudo apt-get install -y libgbm1 libasound2t64 libatk1.0-0 \
           libatk-bridge2.0-0 libcups2 libdrm2 libxcomposite1 \
           libxdamage1 libxfixes3 libxrandr2 libxkbcommon0 \
           libpango-1.0-0 libcairo2 libnss3 libnspr4

--- a/Gemfile
+++ b/Gemfile
@@ -13,3 +13,7 @@ gem 'bigdecimal'
 gem 'logger'
 gem 'mutex_m'
 gem 'rake'
+
+group :jekyll_plugins do
+  gem 'jekyll-mermaid-prebuild', '~> 0.3.0'
+end

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ gem install bundler
 bundle install
 ```
 
+**Note:** This project uses Mermaid diagrams rendered at build time. See [SETUP.md](SETUP.md) for additional dependencies (Node.js, mermaid-cli).
+
 ## Build
 
 ```Shell
@@ -19,8 +21,3 @@ jekyll build --watch
 ```Shell
 jekyll serve
 ```
-
----
-
-
-Publicly accessible via [monori.me](https://www.monori.me)

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,108 @@
+# Local Development Setup
+
+## Prerequisites
+
+This project uses [jekyll-mermaid-prebuild](https://github.com/Texarkanine/jekyll-mermaid-prebuild) to render Mermaid diagrams at build time. This requires additional dependencies.
+
+### Required Dependencies
+
+1. **Ruby 3.2.3+** (for Jekyll)
+2. **Node.js 24+** (for mermaid-cli)
+3. **mermaid-cli** (for diagram rendering)
+4. **Puppeteer dependencies** (for headless Chrome)
+
+### Installation
+
+#### macOS
+
+```bash
+# Install Node.js (if using Homebrew)
+brew install node
+
+# Install mermaid-cli globally
+npm install -g @mermaid-js/mermaid-cli
+
+# Verify installation
+mmdc --version
+```
+
+#### Linux (Debian/Ubuntu/WSL)
+
+```bash
+# Install Node.js
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# Install mermaid-cli globally
+npm install -g @mermaid-js/mermaid-cli
+
+# Install Puppeteer dependencies
+sudo apt-get update
+sudo apt-get install -y libgbm1 libasound2 libatk1.0-0 \
+  libatk-bridge2.0-0 libcups2 libdrm2 libxcomposite1 \
+  libxdamage1 libxfixes3 libxrandr2 libxkbcommon0 \
+  libpango-1.0-0 libcairo2 libnss3 libnspr4
+
+# Verify installation
+mmdc --version
+```
+
+#### Windows
+
+```powershell
+# Install Node.js from https://nodejs.org/
+
+# Install mermaid-cli globally
+npm install -g @mermaid-js/mermaid-cli
+
+# Verify installation
+mmdc --version
+```
+
+## Building the Site
+
+```bash
+# Install Ruby dependencies
+gem install bundler
+bundle install
+
+# Build the site
+bundle exec jekyll build
+
+# Or serve locally with live reload
+bundle exec jekyll serve --livereload
+```
+
+## Verifying Mermaid Diagrams
+
+After building, check that SVG files are generated in `assets/svg/`:
+
+```bash
+ls -la assets/svg/
+```
+
+## Troubleshooting
+
+### "mmdc not found"
+
+Install mermaid-cli:
+```bash
+npm install -g @mermaid-js/mermaid-cli
+```
+
+### "Puppeteer cannot launch headless Chrome" (Linux)
+
+Install the required system libraries:
+```bash
+sudo apt-get update
+sudo apt-get install -y libgbm1 libasound2 libatk1.0-0 \
+  libatk-bridge2.0-0 libcups2 libdrm2 libxcomposite1 \
+  libxdamage1 libxfixes3 libxrandr2 libxkbcommon0 \
+  libpango-1.0-0 libcairo2 libnss3 libnspr4
+```
+
+### Diagrams not rendering
+
+1. Check build output for `MermaidPrebuild:` messages
+2. Verify mmdc works: `mmdc -i test.mmd -o test.svg`
+3. Clear cache: `rm -rf .jekyll-cache/jekyll-mermaid-prebuild/`

--- a/SETUP.md
+++ b/SETUP.md
@@ -38,7 +38,7 @@ npm install -g @mermaid-js/mermaid-cli
 
 # Install Puppeteer dependencies
 sudo apt-get update
-sudo apt-get install -y libgbm1 libasound2 libatk1.0-0 \
+sudo apt-get install -y libgbm1 libasound2t64 libatk1.0-0 \
   libatk-bridge2.0-0 libcups2 libdrm2 libxcomposite1 \
   libxdamage1 libxfixes3 libxrandr2 libxkbcommon0 \
   libpango-1.0-0 libcairo2 libnss3 libnspr4
@@ -95,7 +95,8 @@ npm install -g @mermaid-js/mermaid-cli
 Install the required system libraries:
 ```bash
 sudo apt-get update
-sudo apt-get install -y libgbm1 libasound2 libatk1.0-0 \
+# Ubuntu 24.04+ uses libasound2t64, older versions use libasound2
+sudo apt-get install -y libgbm1 libasound2t64 libatk1.0-0 \
   libatk-bridge2.0-0 libcups2 libdrm2 libxcomposite1 \
   libxdamage1 libxfixes3 libxrandr2 libxkbcommon0 \
   libpango-1.0-0 libcairo2 libnss3 libnspr4

--- a/SETUP.md
+++ b/SETUP.md
@@ -6,7 +6,7 @@ This project uses [jekyll-mermaid-prebuild](https://github.com/Texarkanine/jekyl
 
 ### Required Dependencies
 
-1. **Ruby 3.2.3+** (for Jekyll)
+1. **Ruby 3.4+** (for Jekyll, required by jekyll-mermaid-prebuild)
 2. **Node.js 24+** (for mermaid-cli)
 3. **mermaid-cli** (for diagram rendering)
 4. **Puppeteer dependencies** (for headless Chrome)

--- a/_config.yml
+++ b/_config.yml
@@ -39,8 +39,12 @@ plugins:
   - jekyll-sitemap
   - jekyll-relative-links
   - jekyll-seo-tag
+  - jekyll-mermaid-prebuild
 paginate: 20
 paginate_path: "/blog/page/:num"
+
+mermaid_prebuild:
+  output_dir: assets/svg
 
 collections:
   pages:


### PR DESCRIPTION
## Summary
- Add jekyll-mermaid-prebuild gem for build-time SVG rendering
- Configure output directory (`assets/svg`) for generated diagrams
- Update CI workflow to install mermaid-cli and Puppeteer dependencies

## Why jekyll-mermaid-prebuild?
- **No client-side JavaScript** - diagrams render to static SVG at build time
- **Better SEO** - search engines can index diagram content
- **Faster page loads** - no ~2MB mermaid.js download
- **Caching** - only regenerates changed diagrams

## Usage
Use fenced code blocks with `mermaid` language:

```mermaid
graph TD
    A[Start] --> B[End]
```

## Requirements
- `mmdc` (mermaid-cli) installed globally
- Puppeteer dependencies (for headless Chrome)

## Testing
Will be tested with upcoming blog posts featuring architecture diagrams.